### PR TITLE
Fix help message in live-git-log

### DIFF
--- a/live-git-log
+++ b/live-git-log
@@ -3,7 +3,7 @@
 set -e
 
 usage() {
-    echo "USAGE: live-git-index [-c | --count <max number of commits>]"
+    echo "USAGE: live-git-log [-c | --count <max number of commits>]"
     exit 1
 }
 


### PR DESCRIPTION
I believe that there was some copy/paste not fully edited.
I noticed it while trying the command so I created this pull request